### PR TITLE
Fix test for `ci build`

### DIFF
--- a/minivirt/contrib/ci.py
+++ b/minivirt/contrib/ci.py
@@ -21,7 +21,8 @@ def cli():
 @cli.command()
 @click.argument('image')
 @click.argument('name')
-def build(image, name):
+@click.option('--memory', default=1024)
+def build(image, name, memory):
     from minivirt.cli import db
 
     packages = [
@@ -40,7 +41,7 @@ def build(image, name):
     apk_sed = r's|# \(http://dl-cdn.alpinelinux.org/alpine/.*/community\)|\1|'
     login_shell_sed = r's|\(root:x:0:0:root:/root:\)/bin/ash|\1/bin/bash|'
 
-    vm = VM.create(db, name, db.get_image(image), memory=1024)
+    vm = VM.create(db, name, db.get_image(image), memory=memory)
     with vm.run(wait_for_ssh=30):
         vm.ssh(f'sed -i {shlex.quote(apk_sed)} /etc/apk/repositories')
         vm.ssh(f'apk add {" ".join(packages)}')

--- a/tests/contrib/test_ci.py
+++ b/tests/contrib/test_ci.py
@@ -10,7 +10,7 @@ def test_build(db, monkeypatch):
     monkeypatch.setattr('minivirt.cli.db', db)
     runner = CliRunner()
 
-    res1 = runner.invoke(cli, ['ci', 'build', 'base', 'foo'])
+    res1 = runner.invoke(cli, ['ci', 'build', 'base', 'foo', '--memory=512'])
     assert res1.exit_code == 0
 
     foo = db.get_vm('foo')


### PR DESCRIPTION
[Test output](https://github.com/mgax/minivirt/runs/6955866511?check_suite_focus=true):

```
=================================== FAILURES ===================================
__________________________________ test_build __________________________________
db = <minivirt.db.DB object at 0x7ff3cf9d9790>
monkeypatch = <_pytest.monkeypatch.MonkeyPatch object at 0x7ff3cf9d9850>
    @pytest.mark.arch('x86_64')
    @pytest.mark.slow
    def test_build(db, monkeypatch):
        monkeypatch.setattr('minivirt.cli.db', db)
        runner = CliRunner()
        res1 = runner.invoke(cli, ['ci', 'build', 'base', 'foo'])
>       assert res1.exit_code == 0
E       AssertionError: assert 1 == 0
E        +  where 1 = <Result ConnectionRefusedError(111, 'Connection refused')>.exit_code
tests/contrib/test_ci.py:14: AssertionError
----------------------------- Captured stderr call -----------------------------
qemu-system-x86_64: cannot set up guest memory 'pc.ram': Out of memory
=========================== short test summary info ============================
FAILED tests/contrib/test_ci.py::test_build - AssertionError: assert 1 == 0
=================== 1 failed, 9 passed in 159.26s (0:02:39) ====================
```