### PR TITLE
Store data in `XDG_STATE_HOME`

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -46,7 +46,7 @@ It's possible to interact with the VM in three ways:
 
 The QEMU VM is set up with [User Networking](https://wiki.qemu.org/Documentation/Networking#User_Networking_.28SLIRP.29), which doesn't interfere with the host's network stack, and the guest SSH port is forwarded to a random port on _localhost_. You can forward more ports with the `--port` option.
 
-Minivirt manages [images](#images), which are essentially read-only, reusable virtual machine qcow2 disks; and [VMs](#persistent-vms), with their own [copy-on-write](https://en.wikibooks.org/wiki/QEMU/Images#Copy_on_write) disk, which uses the image disk as its backing file. Everything is stored in `~/.cache/minivirt/`.
+Minivirt manages [images](#images), which are essentially read-only, reusable virtual machine qcow2 disks; and [VMs](#persistent-vms), with their own [copy-on-write](https://en.wikibooks.org/wiki/QEMU/Images#Copy_on_write) disk, which uses the image disk as its backing file. Everything is stored in `~/.local/state/minivirt/`.
 
 ### Doctor
 

--- a/minivirt/cli.py
+++ b/minivirt/cli.py
@@ -1,26 +1,22 @@
 import hashlib
 import logging
-import os
 import re
 import subprocess
 import sys
-from pathlib import Path
 from time import time
 
 import click
 
 from . import build, qemu, remotes
 from .contrib import githubactions
-from .db import DB, ImageNotFound
+from .db import DB, get_db_path, ImageNotFound
 from .exceptions import RemoteNotFound, VmExists, VmIsRunning
 from .vms import PortForward, VM
 
 logger = logging.getLogger(__name__)
 
-_db_path = os.environ.get(
-    'MINIVIRT_DB_PATH', Path.home() / '.cache' / 'minivirt'
-)
-db = DB(Path(_db_path))
+
+db = DB(get_db_path())
 
 
 def parse_port_args(args):

--- a/minivirt/db.py
+++ b/minivirt/db.py
@@ -252,3 +252,16 @@ class DB:
                 logger.info('Removing %s', image.name)
                 if not dry_run:
                     image.delete()
+
+
+def get_db_path(dirname='minivirt', env=True):
+    if env:
+        env_value = os.environ.get('MINIVIRT_DB_PATH')
+        if env_value:
+            return Path(env_value)
+
+    state_path = os.environ.get('XDG_STATE_HOME')
+    if not state_path:
+        state_path = Path.home() / '.local' / 'state'
+
+    return Path(state_path) / dirname

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,13 +5,13 @@ from pathlib import Path
 
 import pytest
 
-from minivirt.db import DB
+from minivirt.db import DB, get_db_path
 from minivirt.qemu import arch
 from minivirt.vms import VM
 
 logger = logging.getLogger(__name__)
 
-CACHE_PATH = Path.home() / '.cache' / 'minivirt-tests'
+CACHE_PATH = get_db_path('minivirt-tests', env=False)
 DB_PATH = CACHE_PATH / 'db'
 BASE_IMAGE_URL = (
     f'https://f003.backblazeb2.com/file/minivirt/alpine-3.15.4-{arch}.tgz'

--- a/tests/ssh_config
+++ b/tests/ssh_config
@@ -1,2 +1,2 @@
 Host *.miv
-  Include ~/.cache/minivirt-tests/db/vms/*/ssh-config
+  Include ~/.local/state/minivirt-tests/db/vms/*/ssh-config


### PR DESCRIPTION
Fixes https://github.com/mgax/minivirt/issues/9.

Docker stores its data under `/var/lib/docker`, and according to https://wiki.archlinux.org/title/XDG_Base_Directory#User_directories, the corresponding directory is `$XDG_STATE_HOME` (`~/.local/state`), so I've used those instead.